### PR TITLE
Fix rule syntax for APT34_VALUEVAULT rule

### DIFF
--- a/rules/APT34_VALUEVAULT.yara
+++ b/rules/APT34_VALUEVAULT.yara
@@ -18,43 +18,43 @@ rule APT34_VALUEVAULT: apt34 infostealer winmalware
         // main.go, mozilla.go, ie.go, etc etc... this should probably be a regex but this works too i guess :|
 
         // some function names
-        str1 = "main.Decrypt" ascii fullword
-        str3 = "main.NewBlob" ascii fullword
-        str4 = "main.CheckFileExist" ascii fullword
-        str5 = "main.CopyFileToDirectory" ascii fullword
-        str6 = "main.CrackChromeBased" ascii fullword
-        str7 = "main.CrackIE" ascii fullword
-        str8 = "main.decipherPassword" ascii fullword
-        str9 = "main.DecodeUTF16" ascii fullword
-        str10 = "main.getHashTable" ascii fullword
-        str11 = "main.getHistory" ascii fullword
-        str12 = "main.getHistoryWithPowerShell" ascii fullword
-        str13 = "main.getHistoryFromRegistery" ascii fullword
-        str14 = "main.main" ascii fullword
-        str15 = "main.DecryptAESFromBase64" ascii fullword
-        str16 = "main.DecryptAES" ascii fullword
+        $str1 = "main.Decrypt" ascii fullword
+        $str3 = "main.NewBlob" ascii fullword
+        $str4 = "main.CheckFileExist" ascii fullword
+        $str5 = "main.CopyFileToDirectory" ascii fullword
+        $str6 = "main.CrackChromeBased" ascii fullword
+        $str7 = "main.CrackIE" ascii fullword
+        $str8 = "main.decipherPassword" ascii fullword
+        $str9 = "main.DecodeUTF16" ascii fullword
+        $str10 = "main.getHashTable" ascii fullword
+        $str11 = "main.getHistory" ascii fullword
+        $str12 = "main.getHistoryWithPowerShell" ascii fullword
+        $str13 = "main.getHistoryFromRegistery" ascii fullword
+        $str14 = "main.main" ascii fullword
+        $str15 = "main.DecryptAESFromBase64" ascii fullword
+        $str16 = "main.DecryptAES" ascii fullword
 
         // typo of Mozilla is intentional
-        str17 = "main.CrackMozila" ascii fullword
-        str18 = "main.decodeLoginData" ascii fullword
-        str19 = "main.decrypt" ascii fullword
-        str20 = "main.removePadding" ascii fullword
-        str21 = "main.getLoginData" ascii fullword
-        str22 = "main.isMasterPasswordCorrect" ascii fullword
-        str23 = "main.decrypt3DES" ascii fullword
-        str24 = "main.getKey" ascii fullword
-        str25 = "main.manageMasterPassword" ascii fullword
-        str26 = "main.getFirefoxProfiles" ascii fullword
-        str27 = "main._Cfunc_DumpVault" ascii fullword
-        str28 = "main.CrackIEandEdgeNew" ascii fullword
-        str29 = "main.init.ializers" ascii fullword
-        str30 = "main.init" ascii fullword
+        $str17 = "main.CrackMozila" ascii fullword
+        $str18 = "main.decodeLoginData" ascii fullword
+        $str19 = "main.decrypt" ascii fullword
+        $str20 = "main.removePadding" ascii fullword
+        $str21 = "main.getLoginData" ascii fullword
+        $str22 = "main.isMasterPasswordCorrect" ascii fullword
+        $str23 = "main.decrypt3DES" ascii fullword
+        $str24 = "main.getKey" ascii fullword
+        $str25 = "main.manageMasterPassword" ascii fullword
+        $str26 = "main.getFirefoxProfiles" ascii fullword
+        $str27 = "main._Cfunc_DumpVault" ascii fullword
+        $str28 = "main.CrackIEandEdgeNew" ascii fullword
+        $str29 = "main.init.ializers" ascii fullword
+        $str30 = "main.init" ascii fullword
 
     condition:
         uint16(0) == 0x5a4d
         and
         (
-            (10 of ($str*) and 3 of ($gopaths*))
+            (10 of ($str*) and 3 of ($gopath*))
             or
             ($fsociety and $powershell and $gobuild)
             or


### PR DESCRIPTION
`yara-python` was throwing a few syntax errors - added `$` to each of the strings and changed `$gopath` from plural to singular in the condition. Rule compiles successfully now with both the yara 3.4.0 binary and yara-python 3.8.0