### PR TITLE
fix: absurd condition

### DIFF
--- a/rules/SilentTrinity_Delivery.yara
+++ b/rules/SilentTrinity_Delivery.yara
@@ -25,6 +25,7 @@ rule SilentTrinity_Delivery_Document
       $s11 = "2. Da biste pogledali dokument, molimo kliknite \"OMOGU" fullword wide
    
    condition:
-      uint16(0) == 0xcfd0 and filesize < 200KB 
-      and (8 of ($s*) or all of them)
+      uint16(0) == 0xcfd0 
+      and filesize < 200KB 
+      and 8 of ($s*)
 }


### PR DESCRIPTION
the condition doesn't make sense anymore. Maybe there were other strings than $s* before but now that there are only $s* strings used in the rule the condition "8 of ($s*) or all of them" doesn't make sense anymore. 